### PR TITLE
Support for virtual_ipaddress_excluded

### DIFF
--- a/templates/default/keepalived.conf.erb
+++ b/templates/default/keepalived.conf.erb
@@ -65,11 +65,21 @@ vrrp_instance <%= name.upcase %> {
     auth_pass <%= instance['auth_pass'] %>
   }
   <% end -%>
+  <% if instance['ip_addresses'] && !instance['ip_addresses'].empty? -%>
   virtual_ipaddress {
     <% Array(instance['ip_addresses']).each do |address| %>
     <%= address %>
     <% end %>
   }
+  <% end -%>
+  <% if instance['ip_addresses_excluded'] && !instance['ip_addresses_excluded'].empty? -%>
+  virtual_ipaddress_excluded {
+    <% Array(instance['ip_addresses_excluded']).each do |address| %>
+    <%= address %>
+    <% end %>
+  }
+  <% end -%>
+
   <% if instance['track_script'] %>
   track_script {
     <%= instance['track_script'] %>

--- a/templates/default/keepalived.conf.erb
+++ b/templates/default/keepalived.conf.erb
@@ -49,6 +49,16 @@ vrrp_instance <%= name.upcase %> {
   <% end -%>
   state <%= states[node.name] || node['keepalived']['instance_defaults']['state'] %>
   priority <%= priorities[node.name] || node['keepalived']['instance_defaults']['priority'] %>
+  <% if instance['notify_master'] -%>
+  notify_master "<%= instance['notify_master'] %>"
+  <% end -%>
+  <% if instance['notify_backup'] -%>
+  notify_backup "<%= instance['notify_backup'] %>"
+  <% end -%>
+  <% if instance['notify_fault'] -%>
+  notify_fault "<%= instance['notify_fault'] %>"
+  <% end -%>
+
   <% if instance['advert_int'] -%>
   advert_int <%= instance['advert_int'] %>
   <% end -%>


### PR DESCRIPTION
Use instance['ip_addresses_excluded'] for virtual_ipaddress_excluded configuration. Make instance['ip_addresses'] and instance['ip_addresses_excluded'] both optional