### PR TITLE
Added a template for /etc/default/keepalived

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,3 +11,4 @@ default['keepalived']['instance_defaults']['priority'] = 100
 default['keepalived']['instance_defaults']['virtual_router_id'] = 10
 default['keepalived']['instances'] = {}
 default['keepalived']['sync_groups'] = nil
+default['keepalived']['daemon_args'] = ''

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,8 +38,16 @@ template "keepalived.conf" do
   mode 0644
 end
 
+template "keepalived.defaults" do
+  path "/etc/default/keepalived"
+  source "keepalived.defaults.erb"
+  owner "root"
+  group "root"
+  mode 0644
+end
+
 service "keepalived" do
   supports :restart => true
   action [:enable, :start]
-  subscribes :restart, "template[keepalived.conf]"
+  subscribes :restart, ["template[keepalived.conf]", "template[keepalived.defaults]"]
 end

--- a/templates/default/keepalived.defaults.erb
+++ b/templates/default/keepalived.defaults.erb
@@ -1,0 +1,4 @@
+# Options to pass to keepalived
+
+# DAEMON_ARGS are appended to the keepalived command-line
+DAEMON_ARGS="<%= node['keepalived']['daemon_args'] %>"

--- a/test/kitchen/cookbooks/keepalived_test/files/default/tests/minitest/configured_test.rb
+++ b/test/kitchen/cookbooks/keepalived_test/files/default/tests/minitest/configured_test.rb
@@ -9,6 +9,10 @@ describe_recipe 'keepalived_test::configured' do
       file('/etc/keepalived/keepalived.conf').must_exist
     end
 
+    it 'should create a default arguments configuration file' do
+      file('/etc/default/keepalived').must_exist
+    end
+
     it 'should enable and start the daemon' do
       service('keepalived').must_be_running
       service('keepalived').must_be_enabled


### PR DESCRIPTION
 Added a template for '/etc/default/keepalived' and an attribute 'daemon_args' to supply args to the daemon e.g. --snmp to enable snmp logging.