### PR TITLE
Vrrp unicast options

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Multiple instances can be defined. The key will be used to define the instance n
 * `:auth_type => nil`             # Enable authentication (:pass or :ah)
 * `:auth_pass => 'secret'`        # Password used for authentication
 * `:unicast_peer => {}`           # IP address(es) for unicast (only for 1.2.8 and greater)
+* `:vrrp_unicast_bind => '10.0.1.100'` # IP address(es) for unicast (only for 1.2.7 and lower)
+* `:vrrp_unicast_peer => '10.0.1.200'` # IP address(es) for unicast (only for 1.2.7 and lower)
 
 ### Vrrp Sync Groups
 

--- a/templates/default/keepalived.conf.erb
+++ b/templates/default/keepalived.conf.erb
@@ -59,11 +59,11 @@ vrrp_instance <%= name.upcase %> {
     <% end %>
   }
   <% end -%>
-  <% if instance['vrrp_unicast_peer'] %>
-  vrrp_unicast_peer <%= instance['vrrp_unicast_peer'] %>
-  <% end %>
   <% if instance['vrrp_unicast_bind'] %>
   vrrp_unicast_bind <%= instance['vrrp_unicast_bind'] %>
+  <% end %>
+  <% if instance['vrrp_unicast_peer'] %>
+  vrrp_unicast_peer <%= instance['vrrp_unicast_peer'] %>
   <% end %>
   <% if instance['auth_type'] -%>
   authentication {

--- a/templates/default/keepalived.conf.erb
+++ b/templates/default/keepalived.conf.erb
@@ -59,6 +59,12 @@ vrrp_instance <%= name.upcase %> {
     <% end %>
   }
   <% end -%>
+  <% if instance['vrrp_unicast_peer'] %>
+  vrrp_unicast_peer <%= instance['vrrp_unicast_peer'] %>
+  <% end %>
+  <% if instance['vrrp_unicast_bind'] %>
+  vrrp_unicast_bind <%= instance['vrrp_unicast_bind'] %>
+  <% end %>
   <% if instance['auth_type'] -%>
   authentication {
     auth_type <%= instance['auth_type'].to_s.upcase %>


### PR DESCRIPTION
In version 1.2.7 we have the these two options:

vrrp_unicast_peer
vrrp_unicast_bind

These seem to similar to the newer unicast_peer block syntax
support by 1.2.8+

Currently Ubuntu 14.04 LTS installs Keepalived v1.2.7 (08/14,2013)
requiring the options to be specified in this manner.