### PR TITLE
allow state/priority/virtual_router_id to be set in instance vars.

### DIFF
--- a/templates/default/keepalived.conf.erb
+++ b/templates/default/keepalived.conf.erb
@@ -49,7 +49,7 @@ vrrp_script <%= name %> {
 -%>
 vrrp_instance <%= name.upcase %> {
   interface <%= instance['interface'] %>
-  virtual_router_id <%= virtual_router_ids[node.name] || node['keepalived']['instance_defaults']['virtual_router_id'] %>
+  virtual_router_id <%= virtual_router_ids[node.name] || instance['virtual_router_id'] || node['keepalived']['instance_defaults']['virtual_router_id'] %>
   <% if instance['garp_master_delay'] %>
   garp_master_delay <%= instance['garp_master_delay'] %>
   <% end %>
@@ -65,8 +65,8 @@ vrrp_instance <%= name.upcase %> {
   <% if instance['nopreempt'] -%>
   nopreempt
   <% end -%>
-  state <%= states[node.name] || node['keepalived']['instance_defaults']['state'] %>
-  priority <%= priorities[node.name] || node['keepalived']['instance_defaults']['priority'] %>
+  state <%= states[node.name] || instance['state'] || node['keepalived']['instance_defaults']['state'] %>
+  priority <%= priorities[node.name] || instance['priority'] || node['keepalived']['instance_defaults']['priority'] %>
   <% if instance['advert_int'] -%>
   advert_int <%= instance['advert_int'] %>
   <% end -%>


### PR DESCRIPTION
provide some middle ground between the per-host values for id/state/priority and the instance_defaults. it will now look per-host, then in the instance attrs (missing before now), then the instance_defaults. in the current state, you could not run multiple instances will differing ids (or state/priority), but this should allow it, while preserving the existing behaviours.
