### PR TITLE
woops, retry is a reserved word

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,6 @@ Example:
 
 ```ruby
 keepalived_smtp_check 'postfix' do
-  retry 3
   helo_name node.name
   host connect_timeout: 30
 end
@@ -485,7 +484,6 @@ Supported properties:
 Property           | Type                                                                                     | Default
 ------------------ | ---------------------------------------------------------------------------------------- | -------
 connect_timeout    | Integer                                                                                  | nil
-retry              | Integer                                                                                  | nil
 delay_before_retry | nil
 helo_name          | String                                                                                   | nil
 warmup             | Integer                                                                                  | nil

--- a/libraries/keepalived.rb
+++ b/libraries/keepalived.rb
@@ -238,7 +238,6 @@ module Keepalived
           end
         }
       },
-      retry: { kind_of: Integer },
       delay_before_retry: { kind_of: Integer },
       helo_name: { kind_of: String },
       connect_timeout: { kind_of: Integer }

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -4,7 +4,6 @@ describe Keepalived::Helpers do
   let(:smtp_check) do
     ChefKeepalived::Resource::SmtpCheck.new('port-465').tap do |r|
       r.fwmark 3
-      r.retry 3
       r.delay_before_retry 10
       r.helo_name 'smtp.example.com'
       r.warmup 3
@@ -20,7 +19,7 @@ describe Keepalived::Helpers do
   end
 
   let(:smtp_check_string) do
-    "fwmark 3\n\twarmup 3\n\thost {\n\t\tconnect_ip 192.168.1.20\n\t\tconnect_port 3306\n\t\tbindto 192.168.1.5\n\t\tbind_port 3308\n\t\tconnect_timeout 5\n\t\tfwmark 3\n\t\t}\n\tretry 3\n\tdelay_before_retry 10\n\thelo_name smtp.example.com"
+    "fwmark 3\n\twarmup 3\n\thost {\n\t\tconnect_ip 192.168.1.20\n\t\tconnect_port 3306\n\t\tbindto 192.168.1.5\n\t\tbind_port 3308\n\t\tconnect_timeout 5\n\t\tfwmark 3\n\t\t}\n\tdelay_before_retry 10\n\thelo_name smtp.example.com"
   end
 
   it 'converts a resource to an appropriate sub-block' do

--- a/spec/unit/resources_spec.rb
+++ b/spec/unit/resources_spec.rb
@@ -309,7 +309,6 @@ end
 describe ChefKeepalived::Resource::SmtpCheck do
   let(:smtp_check) do
     ChefKeepalived::Resource::SmtpCheck.new('port-465').tap do |r|
-      r.retry 3
       r.delay_before_retry 10
       r.helo_name 'smtp.example.com'
       r.warmup 3
@@ -325,7 +324,7 @@ describe ChefKeepalived::Resource::SmtpCheck do
   end
 
   let(:smtp_check_string) do
-    "SMTP_CHECK {\n\twarmup 3\n\thost {\n\t\tconnect_ip 192.168.1.20\n\t\tconnect_port 3306\n\t\tbindto 192.168.1.5\n\t\tbind_port 3308\n\t\tconnect_timeout 5\n\t\tfwmark 3\n\t\t}\n\tretry 3\n\tdelay_before_retry 10\n\thelo_name smtp.example.com\n\t}"
+    "SMTP_CHECK {\n\twarmup 3\n\thost {\n\t\tconnect_ip 192.168.1.20\n\t\tconnect_port 3306\n\t\tbindto 192.168.1.5\n\t\tbind_port 3308\n\t\tconnect_timeout 5\n\t\tfwmark 3\n\t\t}\n\tdelay_before_retry 10\n\thelo_name smtp.example.com\n\t}"
   end
 
   it 'sets a proper smtp_check configuration' do


### PR DESCRIPTION
### Description

removes property that overlaps with ruby reserved word; if it's needed, it can be passed directly into content property of the keepalived_config resource... i'm actually kind of shocked this actually worked o_O

### Issues Resolved

#35

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


