### PR TITLE
rm sysctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,8 @@ Installs keepalived and generates the configuration files, using resource-driven
 
 - `keepalived::default`: loads the install, configure, and service recipes
 - `keepalived::install`: installs the `keepalived` package
-- `keepalived::configure`: configures `/etc/keepalived/keepalived.conf` based on attributes, or sets up include for resource-driven configuration.
+- `keepalived::configure`: configures `/etc/keepalived/keepalived.conf` for inclusion of `keepalived_*` resources
 - `keepalived::service`: enables/starts the `keepalived` service, sets a restart subscription to `/etc/keepalived/keepalived.conf`.
-
-## Attribute Usage
-
-### Configuration settings
-
-- `node['keepalived']['shared_address'] = true` # If keepalived is using a shared address
 
 ## Resource Usage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,0 @@
-default['keepalived']['shared_address'] = false

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -17,18 +17,6 @@
 # limitations under the License.
 #
 
-# Configure sysctl to permit binding to non-local addresses
-if node['keepalived']['shared_address']
-  file '/etc/sysctl.d/60-ip-nonlocal-bind.conf' do
-    mode '0644'
-    content "net.ipv4.ip_nonlocal_bind=1\n"
-  end
-
-  service 'procps' do
-    action :start
-  end
-end
-
 # Set up directories for resource-generated configs
 [
   Keepalived::CONFIG_PATH,

--- a/spec/unit/recipes/configure_spec.rb
+++ b/spec/unit/recipes/configure_spec.rb
@@ -1,26 +1,6 @@
 require 'spec_helper'
 
 describe 'keepalived::configure' do
-  context 'shared address' do
-    let(:chef_run) do
-      ChefSpec::ServerRunner.new do |node|
-        node.set['keepalived']['shared_address'] = true
-      end.converge(described_recipe)
-    end
-
-    it 'sets net.ipv4.ip_nonlocal_bind sysctl' do
-      expect(chef_run).to create_file('/etc/sysctl.d/60-ip-nonlocal-bind.conf').with(
-        mode: '0644',
-        content: "net.ipv4.ip_nonlocal_bind=1\n"
-      )
-      expect(chef_run).to start_service 'procps'
-    end
-
-    it 'converges successfully' do
-      chef_run # This should not raise an error
-    end
-  end
-
   context 'resource-driven' do
     let(:chef_run) do
       ChefSpec::ServerRunner.new do |node|
@@ -28,12 +8,7 @@ describe 'keepalived::configure' do
       end.converge(described_recipe)
     end
 
-    it 'skips net.ipv4.ip_nonlocal_bind sysctl management' do
-      expect(chef_run).to_not create_file '/etc/sysctl.d/60-ip-nonlocal-bind.conf'
-      expect(chef_run).to_not start_service 'procps'
-    end
-
-    it 'creates the resource-driven resources' do
+    it 'creates the resource-driven resource include dirs' do
       %w( conf.d servers.d checks.d ).each do |d|
         expect(chef_run).to create_directory("/etc/keepalived/#{d}").with(
           owner: 'root',


### PR DESCRIPTION
### Description

take the opportunity while we're breaking compat to remove sysctl management from cookbook. nonlocal bind is a common sysctl deployed with keepalived, but it's honestly out of scope for this cookbook, and it'd be better to use a cookbook that deals with sysctl management explicitly in cases where sysctl management is needed (e.g. the way this was done was problematic for EL distros).

### Issues Resolved

n/a

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


