### PR TITLE
Keepalived daemon args (closes #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,20 @@ Installs keepalived and generates the configuration files, using resource-driven
 - `keepalived::configure`: configures `/etc/keepalived/keepalived.conf` for inclusion of `keepalived_*` resources
 - `keepalived::service`: enables/starts the `keepalived` service, sets a restart subscription to `/etc/keepalived/keepalived.conf`.
 
+### Attributes
+
+- `default['keepalived']['package']`: specify package name to install (e.g. 'keepalived/trusty-backports').
+- `default['keepalived']['daemon_args']`: array of args to override default daemon cli args with
+- `default['keepalived']['daemon_args_env_var']`: name of env var used by init script to pass in the daemon cli arguments
+- `default['keepalived']['defaults_path']`: path of file to write daemon cli arg env var to (e.g. "/etc/default/keepalived")
+
 ## Resource Usage
 
-This cookbook provides a set of resources for managing keepalived via LWRPs, for cases where resource-driven configuratino may be preferable. These resources rely on support for the `include` directive, supported since keepalived version `1.1.15`, released in Sept, 2007\. Please confirm your vendor package supports this before attempting to use these resources.
+This cookbook provides a set of resources for managing keepalived via LWRPs. These resources rely on support for the `include` directive, supported since keepalived version `1.1.15`, released in Sept, 2007. Please confirm your vendor package supports this before attempting to use these resources.
 
 ### Generic Config
 
-The `keepalived_config` resource is the base resource on which other resources are built. It's not generally intended for direct consumption, but can be used in a pinch to provide a custom configuration if needed via the config property.
+The `keepalived_config` resource is the base resource on which other resources are built. It's not generally intended for direct consumption, but can be used in a pinch to provide a custom configuration if needed via the content property.
 
 Example:
 
@@ -55,6 +62,7 @@ Supported properties:
 Property | Type   | Default
 -------- | ------ | --------
 content  | String | #to_conf
+path     | String | dynamically computed
 
 ### Global Defs
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,16 @@
+# Can be useful to override on Ubuntu
+# e.g. 'keepalived/trusty-backports'
+default['keepalived']['package'] = 'keepalived'
+
+# Not supported in Debian 7 or Ubuntu 12
 default['keepalived']['daemon_args'] = %w()
+
+default['keepalived']['daemon_args_env_var'] =
+  node['platform_family'] == 'debian' ? 'DAEMON_ARGS' : 'KEEPALIVED_OPTIONS'
+
+default['keepalived']['defaults_path'] =
+  if node['platform_family'] == 'debian'
+    '/etc/default/keepalived'
+  else
+    '/etc/sysconfig/keepalived'
+  end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,1 @@
-default['keepalived']['shared_address'] = false
+default['keepalived']['daemon_args'] = %w()

--- a/libraries/provider.rb
+++ b/libraries/provider.rb
@@ -62,6 +62,9 @@ class ChefKeepalived
       def manage_config_file(action = :nothing)
         Chef::Resource::File.new(new_resource.path, run_context).tap do |f|
           f.content "#{new_resource.content}\n"
+          f.owner 'root'
+          f.group 'root'
+          f.mode '0640'
         end.run_action(action)
       end
     end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -42,6 +42,22 @@ end
   end
 end
 
+args = node['keepalived']['daemon_args']
+
+file 'keepalived-options' do
+  case node['platform_family']
+  when 'rhel', 'fedora'
+    path '/etc/sysconfig/keepalived'
+  else
+    path '/etc/default/keepalived'
+  end
+  content "KEEPALIVED_OPTIONS='#{args.join(' ')}'"
+  owner 'root'
+  group 'root'
+  mode '0640'
+  not_if { args.empty? }
+end
+
 # Include resource-generated configs
 file 'keepalived.conf' do
   path "#{Keepalived::ROOT_PATH}/keepalived.conf"

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -42,16 +42,13 @@ end
   end
 end
 
+# Set up daemon argument overrides
 args = node['keepalived']['daemon_args']
+env_var = node['keepalived']['daemon_args_env_var']
 
 file 'keepalived-options' do
-  case node['platform_family']
-  when 'rhel', 'fedora'
-    path '/etc/sysconfig/keepalived'
-  else
-    path '/etc/default/keepalived'
-  end
-  content "KEEPALIVED_OPTIONS='#{args.join(' ')}'"
+  path node['keepalived']['defaults_path']
+  content "#{env_var}='#{args.join(' ')}'"
   owner 'root'
   group 'root'
   mode '0640'

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -64,5 +64,5 @@ file 'keepalived.conf' do
   content "include #{Keepalived::CONFIG_PATH}/*.conf\n"
   owner 'root'
   group 'root'
-  mode '0644'
+  mode '0640'
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -17,4 +17,4 @@
 # limitations under the License.
 #
 
-package 'keepalived'
+package node['keepalived']['package']

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -20,5 +20,6 @@
 service 'keepalived' do
   supports restart: true
   action [:enable, :start]
-  subscribes :restart, 'file[keepalived.conf]'
+  subscribes :restart, 'file[keepalived.conf]', :delayed
+  subscribes :restart, 'file[keepalived-options]', :delayed
 end

--- a/spec/unit/recipes/configure_spec.rb
+++ b/spec/unit/recipes/configure_spec.rb
@@ -3,9 +3,7 @@ require 'spec_helper'
 describe 'keepalived::configure' do
   context 'resource-driven' do
     let(:chef_run) do
-      ChefSpec::ServerRunner.new do |node|
-        node.set['keepalived']['use_attributes'] = false
-      end.converge(described_recipe)
+      ChefSpec::ServerRunner.new.converge(described_recipe)
     end
 
     it 'creates the resource-driven resource include dirs' do
@@ -17,12 +15,36 @@ describe 'keepalived::configure' do
         )
       end
 
+      expect(chef_run).to_not create_file('keepalived-options')
+
       expect(chef_run).to create_file('keepalived.conf').with(
         path: '/etc/keepalived/keepalived.conf',
         content: "include /etc/keepalived/conf.d/*.conf\n",
         owner: 'root',
         group: 'root',
         mode: '0640'
+      )
+    end
+
+    it 'converges successfully' do
+      chef_run # This should not raise an error
+    end
+  end
+
+  context 'daemon-args' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new do |node|
+        node.set['keepalived']['daemon_args'] = %w( -D --snmp )
+      end.converge(described_recipe)
+    end
+
+    it 'creates the defaults file' do
+      expect(chef_run).to create_file('keepalived-options').with(
+        path: '/etc/sysconfig/keepalived',
+        owner: 'root',
+        group: 'root',
+        mode: '0640',
+        content: "KEEPALIVED_OPTIONS='-D --snmp'"
       )
     end
 

--- a/spec/unit/recipes/configure_spec.rb
+++ b/spec/unit/recipes/configure_spec.rb
@@ -47,7 +47,7 @@ describe 'keepalived::configure' do
         content: "include /etc/keepalived/conf.d/*.conf\n",
         owner: 'root',
         group: 'root',
-        mode: '0644'
+        mode: '0640'
       )
     end
 


### PR DESCRIPTION
### Description

- permits customizing the daemon args
- permits overriding the package name
- converts config files to mode 640, since they may contain "secrets" (e.g. vrrp auth pass)

### Issues Resolved

#38 

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

