### PR TITLE
Allow passing sensitive attribute through to File resource

### DIFF
--- a/libraries/provider.rb
+++ b/libraries/provider.rb
@@ -65,6 +65,7 @@ class ChefKeepalived
           f.owner 'root'
           f.group 'root'
           f.mode '0640'
+          f.sensitive new_resource.sensitive if defined?(:sensitive)
         end.run_action(action)
       end
     end

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -51,6 +51,7 @@ keepalived_vrrp_instance 'inside_network' do
     auth_pass: 'buttz'
   )
   virtual_ipaddress %w( 192.168.4.92 )
+  sensitive true
 end
 
 keepalived_vrrp_instance 'outside_network' do


### PR DESCRIPTION
### Description

Allows providers generating files to be sensitive.  This is useful for securing passwords from Chef logs.

### Issues Resolved

Provides ability to secure passwords when using providers.

### Check List
- [X] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
 - Failing rubocop tests not from changes I've introduced
- [ ] New functionality includes testing.
 - Wasn't sure how to add testing
- [X] New functionality has been documented in the README if applicable
 - No changes to README.md ... trying to emulate existing global Chef functionality for [sensitive](https://docs.chef.io/resource_common.html)
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD

