### PR TITLE
chef_version is only available since 12.6.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -17,4 +17,4 @@ end
 
 source_url 'https://github.com/chef-cookbooks/keepalived'
 issues_url 'https://github.com/chef-cookbooks/keepalived/issues'
-chef_version '>= 12.1'
+chef_version '>= 12.1' if respond_to?(:chef_version)


### PR DESCRIPTION
without this fix with older chef versions (eg. 12.4 which should be supported) you will receive ERROR: undefined method chef_version' for #<Chef::Cookbook::Metadata:0x00000001c68008>