### PR TITLE
Update README for vrrp_instance property name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Example:
 
 ```ruby
 keepalived_vrrp_instance 'inside_network' do
-  state 'MASTER'
+  master true
   interface node['network']['default_interface']
   virtual_router_id 51
   priority 101


### PR DESCRIPTION
### Description

Update the README to match the keepalived_vrrp_instance `state` property name change for Chef 13.

### Issues Resolved

Updates documentation to accurately reflect the keepalived_vrrp_instance resource. 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
