### PR TITLE
Changes needed to converge on CentOS7 and Debian9

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -3,6 +3,7 @@
 # Recipe:: configure
 #
 # Copyright:: 2009-2016, Chef Software, Inc.
+# Copyright:: 2018, Workday, Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,6 +48,14 @@ end
 file 'keepalived.conf' do
   path "#{Keepalived::ROOT_PATH}/keepalived.conf"
   content "include #{Keepalived::CONFIG_PATH}/*.conf\n"
+  owner 'root'
+  group 'root'
+  mode '0640'
+end
+
+# Create a dummy config file in the resource-generated configs directory
+file File.join(Keepalived::CONFIG_PATH, 'empty.conf') do
+  content '# Some versions of Keepalived won\'t start when include dir is empty'
   owner 'root'
   group 'root'
   mode '0640'

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -3,7 +3,7 @@
 # Recipe:: configure
 #
 # Copyright:: 2009-2016, Chef Software, Inc.
-# Copyright:: 2018, Workday, Ltd.
+# Copyright:: 2018, Workday, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/unit/recipes/configure_spec.rb
+++ b/spec/unit/recipes/configure_spec.rb
@@ -24,6 +24,13 @@ describe 'keepalived::configure' do
         group: 'root',
         mode: '0640'
       )
+
+      expect(chef_run).to create_file('/etc/keepalived/conf.d/empty.conf').with(
+        content: '# Some versions of Keepalived won\'t start when include dir is empty',
+        owner: 'root',
+        group: 'root',
+        mode: '0640'
+      )
     end
 
     it 'converges successfully' do


### PR DESCRIPTION
### Description

This change fixes an issue where the keepalived service does not start on the latest versions of
CentOS 7 and Debian 9 hence keepalived::default recipe does not converge.

### Issues Resolved

#62 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
